### PR TITLE
ci(windows): NAGL 小分子電荷を Windows native 検証

### DIFF
--- a/.github/workflows/windows-native.yml
+++ b/.github/workflows/windows-native.yml
@@ -67,13 +67,16 @@ jobs:
           # AmberTools は Windows の conda build が無いため、 ambertools に依存する
           # メタパッケージ `openff-toolkit` は Windows でインストール不可。
           # ambertools 非依存 (RDKit バックエンド) の `openff-toolkit-base` を使う。
-          # 本 smoke は ff14SB の library charges のみ使い AM1-BCC (sqm) を呼ばないので
-          # base で十分。 新しめの openff-toolkit-base は python>=3.11 が必要。
+          # protein は ff14SB library charges で AM1-BCC (sqm) を呼ばないが、 小分子
+          # (caprate 等) は AM1-BCC 相当電荷が要る → `openff-nagl` (ML 電荷、 pure-Python、
+          # sqm 不要) + model package で Windows native に賄う。 python>=3.11 必要。
           create-args: >-
             python=3.11
             openff-toolkit-base
             openff-interchange
             openff-amber-ff-ports
+            openff-nagl
+            openff-nagl-models
             openmm
             pdbfixer
             rdkit
@@ -86,6 +89,7 @@ jobs:
       - name: OpenFF Windows-native smoke
         shell: bash -el {0}
         run: |
-          # AmberTools 非依存の parametrization 層を検証
-          # (sequence → PeptideBuilder → PDBFixer → Topology.from_pdb → ff14SB Interchange)
+          # AmberTools 非依存の parametrization 層を検証:
+          #  - protein: sequence → PeptideBuilder → PDBFixer → Topology.from_pdb → ff14SB
+          #  - small mol: SMILES → NAGL ML-AM1-BCC 電荷 → Sage Interchange (sqm 不要)
           python -m pytest tests/integration/test_openff_windows_smoke.py -v -m slow

--- a/abmptools/amorphous/molecule_prep.py
+++ b/abmptools/amorphous/molecule_prep.py
@@ -217,8 +217,15 @@ def _maybe_assign_partial_charges(mol: Any, method: str, nagl_model: str) -> Non
     if not method or method == "am1bcc":
         return
     if method == "nagl":
+        # NAGLToolkitWrapper は global toolkit registry に自動登録されないため
+        # 明示的に渡す (openff-nagl が登録済みか否かに依らず動く)。 これが
+        # ML-AM1-BCC 電荷を sqm / AmberTools 無し = Windows native で得る肝。
         try:
-            mol.assign_partial_charges(partial_charge_method=nagl_model)
+            from openff.toolkit.utils.nagl_wrapper import NAGLToolkitWrapper
+            mol.assign_partial_charges(
+                partial_charge_method=nagl_model,
+                toolkit_registry=NAGLToolkitWrapper(),
+            )
         except Exception as e:
             raise RuntimeError(
                 f"Failed to assign NAGL charges using model '{nagl_model}'. "

--- a/tests/integration/test_openff_windows_smoke.py
+++ b/tests/integration/test_openff_windows_smoke.py
@@ -77,6 +77,51 @@ def test_sequence_to_ff14sb_interchange_windows_native(tmp_path):
     assert any(abs(c.m) > 1e-6 for c in charges.values())
 
 
+def test_small_molecule_nagl_charges_windows_native(tmp_path):
+    """小分子 (caprate anion) を NAGL ML-AM1-BCC で電荷付与 → Sage Interchange。
+
+    formulation OpenFF route の最後のピース = 小分子電荷を、 sqm / AmberTools を
+    使わず NAGL (graph neural net、 pure-Python) で **Windows native** に出せる
+    ことを検証する。 protein は library charges で電荷計算不要だが、 caprate /
+    taurocholate のような任意小分子は AM1-BCC 相当電荷が要る — それを NAGL で賄う。
+    """
+    pytest.importorskip("openff.nagl", reason="openff-nagl not installed")
+    pytest.importorskip("openff.nagl_models", reason="openff-nagl-models not installed")
+    from abmptools.formulation.small_molecule_openff import (
+        parameterize_small_mol_openff,
+    )
+    from openff.toolkit import ForceField, Topology
+    from openff.interchange import Interchange
+    from openff.units import unit
+    import numpy as np
+
+    # caprate (decanoate) anion — Hossain 2023 の permeation enhancer (荷電型)
+    res = parameterize_small_mol_openff(
+        smiles="CCCCCCCCCC(=O)[O-]",
+        resname="CPC", net_charge=-1,
+        output_dir=tmp_path, charge_method="nagl",
+    )
+    mol = res.molecule
+    assert res.pdb_path.is_file()
+
+    # NAGL 電荷が割り当てられている (全 0 でない)
+    charges = [c.m_as(unit.elementary_charge) for c in mol.partial_charges]
+    assert len(charges) == mol.n_atoms
+    assert any(abs(c) > 1e-6 for c in charges), "NAGL charges all zero"
+    # NAGL は total charge を formal charge (-1) に保存する
+    assert abs(sum(charges) - (-1.0)) < 0.05, f"charge sum {sum(charges)} != -1"
+
+    # precomputed NAGL charges を使って Sage で Interchange (sqm を呼ばない)
+    top = Topology()
+    top.add_molecule(mol)
+    top.box_vectors = np.eye(3) * 4.0 * unit.nanometer
+    ff = ForceField(SAGE)
+    ic = Interchange.from_smirnoff(
+        force_field=ff, topology=top, charge_from_molecules=[mol],
+    )
+    assert ic.topology.n_atoms == mol.n_atoms
+
+
 def test_pdbfixer_strips_water_adds_hydrogens(tmp_path):
     """PDBFixer が water 除去 + H 付加することを最小確認 (Windows native 前処理)。"""
     from abmptools.formulation.peptide_atomistic_openff import (


### PR DESCRIPTION
## 目的

formulation OpenFF route の最後の AmberTools 依存 = 小分子 (caprate 等) の
AM1-BCC 電荷 (sqm) を **NAGL** (ML graph neural net、 pure-Python、 sqm 不要) で
置換し、 Windows native で動くことを `windows-latest` runner で実機検証する。

## 変更

- `molecule_prep._maybe_assign_partial_charges`: `NAGLToolkitWrapper` を明示的に
  渡す (global toolkit registry 非自動登録対策)
- smoke test: caprate anion → NAGL 電荷 → Sage Interchange (total charge -1 保存確認)
- workflow: conda env に `openff-nagl` + `openff-nagl-models` 追加

CI が緑なら、 protein (library charges) + small mol (NAGL) 両方が AmberTools 無しで
Windows native に組めることが裏付けられる。